### PR TITLE
Fix bugs about mutex

### DIFF
--- a/src/mintsystem/gcc/mutex.c
+++ b/src/mintsystem/gcc/mutex.c
@@ -5,7 +5,11 @@ int mint_mutex_init(mint_mutex_t *mutex)
 {
     pthread_mutexattr_t attr;
     pthread_mutexattr_init(&attr);
+#ifdef PTHREAD_MUTEX_RECURSIVE
     pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+#else
+    pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE_NP);
+#endif
     return pthread_mutex_init(mutex, &attr);
 }
 


### PR DESCRIPTION
I failed at compile time.

```
Scanning dependencies of target MintSystem
make[2]: Warning: File `CMakeFiles/MintSystem.dir/depend.make' has modification time 1 s in the future
[ 25%] Building C object CMakeFiles/MintSystem.dir/gcc/semaphore.o
[ 50%] Building C object CMakeFiles/MintSystem.dir/gcc/datetime.o
[ 75%] Building C object CMakeFiles/MintSystem.dir/gcc/mutex.o
/dummy/mintomic/src/mintsystem/gcc/mutex.c: In function 'mint_mutex_init':
/dummy/mintomic/src/mintsystem/gcc/mutex.c:8: error: 'PTHREAD_MUTEX_RECURSIVE' undeclared (first use in this function)
/dummy/mintomic/src/mintsystem/gcc/mutex.c:8: error: (Each undeclared identifier is reported only once
/dummy/mintomic/src/mintsystem/gcc/mutex.c:8: error: for each function it appears in.)
make[2]: *** [CMakeFiles/MintSystem.dir/gcc/mutex.o] Error 1
make[1]: *** [CMakeFiles/MintSystem.dir/all] Error 2
make: *** [all] Error 2
```

gcc 

```
[dummy mintsystem]$ gcc -v
Using built-in specs.
Target: x86_64-redhat-linux6E
Configured with: ../configure --prefix=/usr --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=http://bugzilla.redhat.com/bugzilla --enable-bootstrap --enable-shared --enable-threads=posix --enable-checking=release --with-system-zlib --enable-__cxa_atexit --disable-libunwind-exceptions --disable-gnu-unique-object --with-as=/usr/libexec/binutils220/as --enable-languages=c,c++,fortran --disable-libgcj --with-mpfr=/builddir/build/BUILD/gcc-4.4.7-20120601/obj-x86_64-redhat-linux6E/mpfr-install/ --with-ppl=/builddir/build/BUILD/gcc-4.4.7-20120601/obj-x86_64-redhat-linux6E/ppl-install --with-cloog=/builddir/build/BUILD/gcc-4.4.7-20120601/obj-x86_64-redhat-linux6E/cloog-install --with-tune=generic --with-arch_32=i586 --build=x86_64-redhat-linux6E
Thread model: posix
gcc version 4.4.7 20120313 (Red Hat 4.4.7-1) (GCC) 
```
